### PR TITLE
display return url when editing a study

### DIFF
--- a/frontend/src/screens/studies/edit.tsx
+++ b/frontend/src/screens/studies/edit.tsx
@@ -164,6 +164,11 @@ const StageRow:React.FC<{stage: Stage, onDelete(s: Stage): void}> = ({ stage, on
     )
 }
 
+const StudyLandingUrl: React.FC<{ study: Study }> = ({ study }) => {
+
+    return <pre>{`${window.location.origin}/study/land/${study.id}`}</pre>
+}
+
 export const StudyStages: React.FC<{ study: EditingStudy, onUpdate(): void }> = ({ study, onUpdate }) => {
     const api = useStudyApi()
     const [, meta] = useField({
@@ -181,6 +186,9 @@ export const StudyStages: React.FC<{ study: EditingStudy, onUpdate(): void }> = 
     }
     return (
         <React.Fragment>
+            <Row><Col><p className="lead">This study's return url is:</p></Col></Row>
+            <Row><Col><StudyLandingUrl study={study} /></Col></Row>
+
             <Row className="mb-2">
                 <Col sm={11}><h5>Stages</h5></Col>
                 <Col sm={1}>


### PR DESCRIPTION
That's what researchers will need to use when adding the return step

<img width="753" alt="image" src="https://user-images.githubusercontent.com/79566/135662285-d966d0ff-692c-4b4f-835f-1e0e3073bd00.png">