### PR TITLE
Send study id to qualtrics

### DIFF
--- a/backend/app/models/stage.rb
+++ b/backend/app/models/stage.rb
@@ -18,7 +18,7 @@ class Stage < ApplicationRecord
                else
                  raise "Unsupported stage type: '#{config[:type]}'"
                end
-    launcher.new(config: config, user_id: user_id)
+    launcher.new(config: config, user_id: user_id, study_id: study.id)
   end
 
   protected

--- a/backend/app/services/qualtrics_launcher.rb
+++ b/backend/app/services/qualtrics_launcher.rb
@@ -4,9 +4,10 @@ require 'openssl'
 
 class QualtricsLauncher
 
-  def initialize(config:, user_id:)
+  def initialize(config:, user_id:, study_id:)
     @config = config
     @user_id = user_id
+    @study_id = study_id
   end
 
   def url
@@ -23,6 +24,7 @@ class QualtricsLauncher
 
   attr_reader :config
   attr_reader :user_id
+  attr_reader :study_id
 
   def secret_key
     config[:secret_key]
@@ -33,7 +35,8 @@ class QualtricsLauncher
       [
         ['timestamp', Time.now.utc.iso8601],
         ['expiration', 1.hour.from_now.utc.iso8601],
-        ['research_id', ResearchId.for_user_id(user_id).id]
+        ['research_id', ResearchId.for_user_id(user_id).id],
+        ['study_id', study_id]
       ]
     )
 

--- a/backend/spec/models/admin_spec.rb
+++ b/backend/spec/models/admin_spec.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-require 'rails_helper'
-
-RSpec.describe Admin, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/backend/spec/models/launched_stage_spec.rb
+++ b/backend/spec/models/launched_stage_spec.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-require 'rails_helper'
-
-RSpec.describe LaunchedStage, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/backend/spec/models/launched_study_spec.rb
+++ b/backend/spec/models/launched_study_spec.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-require 'rails_helper'
-
-RSpec.describe LaunchedStudy, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/backend/spec/models/researcher_spec.rb
+++ b/backend/spec/models/researcher_spec.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-require 'rails_helper'
-
-RSpec.describe Researcher, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/backend/spec/models/study_researcher_spec.rb
+++ b/backend/spec/models/study_researcher_spec.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-require 'rails_helper'
-
-RSpec.describe StudyResearcher, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/backend/spec/services/qualtrics_launcher_spec.rb
+++ b/backend/spec/services/qualtrics_launcher_spec.rb
@@ -14,30 +14,40 @@ RSpec.describe QualtricsLauncher do
 
   let(:known_valid_ssotoken) do
     # Generated using "Generate test token" button on Qualtrics survey
-    'FL3ghD3UzMZs0aNasdKlvFkHi3uATPks3wGueHQZ4VXJfR7mKM%2FMV5byH3mJVnHD2Z2Yrn5H0sSNJzdC71TyVv%2FufFVwm%2BQmrBF89IwqnU5RegPUyU7zOzgU78bImEtgE0GFtrZ9R40JPlRiqiZamw%3D%3D'
+    'ql5aeihGrs3oG5tR0BDuaxSGKRVPmfd5zUK08QLn9Ld5gddl7GVTN%2FtZS3j5%2BTZusMRi0EgMi67ocXYrVJs45lbbHEr2w3tr%2BjDv1qZYztIcfWOxH1Ik3ndIudGOkG%2FcQuF88D%2BlIa%2Br1Q%2BC%2FDFi0tH83whoPh%2B52aRbBYolcNk%3D'
   end
 
   let(:user_id) { SecureRandom.uuid }
-  let!(:research_id) { ResearchId.for_user_id(user_id).id }
+  let(:research_id) { '1234' }
+  let(:study_id) { '4321' }
 
   it 'shows we can decrypt a Qualtrics-generated token' do
-    expect(decrypt_research_id(url: "https://blah.com?ssotoken=#{known_valid_ssotoken}", key: config[:secret_key])).to eq 'foo'
+    expect(
+      decrypt_params(url: "https://blah.com?ssotoken=#{known_valid_ssotoken}", key: config[:secret_key])
+    ).to eq(
+      'research_id' => research_id,
+      'study_id' => study_id
+    )
   end
 
-  it 'works' do
-    launcher = described_class.new(config: config, user_id: user_id)
-    expect(decrypt_research_id(url: launcher.url, key: config[:secret_key])).to eq research_id
+  it 'generates and decypts a token' do
+    research_id = ResearchId.for_user_id(user_id).id
+    launcher = described_class.new(config: config, user_id: user_id, study_id: study_id)
+    expect(decrypt_params(url: launcher.url, key: config[:secret_key])).to eq(
+      'research_id' => research_id,
+      'study_id' => study_id
+    )
   end
 
   it 'previews' do
-    expect(described_class.new(config: config, user_id: user_id).preview_url).to match(/Q_CHL=preview/)
+    expect(described_class.new(config: config, user_id: user_id, study_id: study_id).preview_url).to match(/Q_CHL=preview/)
   end
 
-  def decrypt_research_id(url:, key:)
+  def decrypt_params(url:, key:)
     url = URI(url)
     hash = URI.decode_www_form(url.query).to_h
     query_params = URI.decode_www_form(decrypt(token_value: hash['ssotoken'], key: key)).to_h
-    query_params['research_id']
+    query_params.slice('research_id', 'study_id')
   end
 
   def decrypt(token_value:, key:)
@@ -48,3 +58,4 @@ RSpec.describe QualtricsLauncher do
   end
 
 end
+# 1wkgUd7A/kZFfroc


### PR DESCRIPTION
By passing the  study id to qualtrics, surveys can set the return url to be:

`https://kenetic.openstax.org/study/land/${e://Field/study_id}` or `https://staging.kenetic.openstax.org/study/land/${e://Field/study_id}` for testing

<img width="655" alt="image" src="https://user-images.githubusercontent.com/79566/135915647-3033e6e5-37f8-44e6-aea4-7d6c8c1cb13a.png">

When setting up the study, two pieces of embedded data must be specified, the `research_id` and `study_id`

<img width="1087" alt="image" src="https://user-images.githubusercontent.com/79566/135915704-581f1a85-2f03-4a05-9fec-f752359a4524.png">

